### PR TITLE
remove form module dependecy to simplify data binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export class AppModule { }
 
 In your templates, use the `google-chart` component like this:
 ```html
-<google-chart [(ngModel)]="pieChartOptions"></google-chart>
+<google-chart [data]="pieChartOptions"></google-chart>
 ```
 and in the corresponding `.ts` file:
 ```ts

--- a/example/package.json
+++ b/example/package.json
@@ -14,11 +14,8 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "~2.1.0",
     "@angular/compiler": "~2.1.0",
     "@angular/core": "~2.1.0",
-    "@angular/forms": "~2.1.0",
-    "@angular/http": "~2.1.0",
     "@angular/platform-browser": "~2.1.0",
     "@angular/platform-browser-dynamic": "~2.1.0",
     "@angular/router": "~3.1.0",

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -1,11 +1,11 @@
 <h1>Column chart</h1>
-<google-chart [(ngModel)]="columnChartOptions"></google-chart>
+<google-chart [data]="columnChartOptions"></google-chart>
 <input type="button" value="Change data" (click)="myClick()">
 <h1>Pie chart</h1>
-<google-chart [(ngModel)]="pieChartOptions"></google-chart>
+<google-chart [data]="pieChartOptions"></google-chart>
 <h1>Gauge</h1>
 <div style="width: 1px; margin: 0 auto;">
-  <google-chart [(ngModel)]="gaugeChartOptions"></google-chart>
+  <google-chart [data]="gaugeChartOptions"></google-chart>
 </div>
 <h1>Scatter chart</h1>
-<google-chart [(ngModel)]="scatterChartOptions"></google-chart>
+<google-chart [data]="scatterChartOptions"></google-chart>

--- a/example/src/app/app.module.ts
+++ b/example/src/app/app.module.ts
@@ -1,7 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { HttpModule } from '@angular/http';
 
 import { AppComponent } from './app.component';
 
@@ -13,8 +11,6 @@ import { Ng2GoogleChartsModule } from 'ng2-google-charts';
   ],
   imports: [
     BrowserModule,
-    FormsModule,
-    HttpModule,
     Ng2GoogleChartsModule,
   ],
   providers: [],

--- a/package.json
+++ b/package.json
@@ -31,10 +31,8 @@
   },
   "homepage": "https://github.com/gmazzamuto/ng2-google-charts",
   "devDependencies": {
-    "@angular/common": "^2.0.0",
     "@angular/compiler": "^2.0.0",
     "@angular/core": "^2.0.0",
-    "@angular/forms": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
     "jasmine-core": "^2.4.1",
@@ -55,8 +53,6 @@
     "zone.js": "^0.6.23"
   },
   "peerDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/core": "^2.0.0",
-    "@angular/forms": "^2.0.0"
+    "@angular/core": "^2.0.0"
   }
 }

--- a/src/google-chart/google-chart.component.spec.ts
+++ b/src/google-chart/google-chart.component.spec.ts
@@ -3,8 +3,6 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { Component } from '@angular/core';
 
-import { FormsModule } from '@angular/forms';
-
 import { Ng2GoogleChartsModule } from '../google-charts.module';
 import { GoogleChartsLoaderService } from '../google-charts-loader.service';
 
@@ -26,7 +24,6 @@ describe('Component: GoogleChart', () => {
         TestChartComponent,
       ],
       imports: [
-        FormsModule,
         Ng2GoogleChartsModule
       ],
       providers: [
@@ -56,7 +53,7 @@ describe('Component: GoogleChart', () => {
 
 @Component({
   selector: 'app-test-chart',
-  template: '<google-chart [(ngModel)]="testChartData" ngDefaultControl></google-chart>',
+  template: '<google-chart data="testChartData"></google-chart>',
 })
 class TestChartComponent {
   public testChartData =  {

--- a/src/google-chart/google-chart.component.ts
+++ b/src/google-chart/google-chart.component.ts
@@ -3,73 +3,43 @@ declare var google: any;
 import {
   Component,
   ElementRef,
-  forwardRef,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  OnChanges,
+  Input,
+  SimpleChanges
 } from '@angular/core';
 
-import {
-  NG_VALUE_ACCESSOR,
-  ControlValueAccessor
-} from '@angular/forms';
-
 import { GoogleChartsLoaderService } from '../google-charts-loader.service';
-
-export const GOOGLE_CHART_COMPONENT_VALUE_ACCESSOR: any = {
-    provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => GoogleChartComponent),
-    multi: true
-};
 
 @Component({
   selector: 'google-chart',
   template: '<div></div>',
-  providers: [GOOGLE_CHART_COMPONENT_VALUE_ACCESSOR],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class GoogleChartComponent implements ControlValueAccessor {
+export class GoogleChartComponent implements OnChanges {
+  @Input()
+  data: any;
 
-  dataModel: any;
-
-  private wrapper: any;
-
-  private onChange: any = Function.prototype;
-  private onTouched: any = Function.prototype;
+  wrapper: any;
 
   constructor(private el: ElementRef,
     private loaderService: GoogleChartsLoaderService) {}
 
-  //get accessor
-  get value(): any {
-    return this.dataModel;
-  };
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['data']) {
+      if(this.data === null) {
+        return;
+      }
 
-  set value(v: any) {
-    if (v !== this.dataModel) {
-        this.dataModel = v;
-        this.onChange(v);
-    }
-  }
-
-  //ControlValueAccessor interface
-  writeValue(value: any) {
-    if(value === null) {
-      return;
-    }
-    if (value !== this.dataModel) {
-      this.dataModel = value;
-      this.loaderService.load(this.dataModel.chartType).then(() => {
+      this.loaderService.load(this.data.chartType).then(() => {
         if(this.wrapper === undefined) {
-          this.wrapper = new google.visualization.ChartWrapper(this.dataModel);
+          this.wrapper = new google.visualization.ChartWrapper(this.data);
         } else {
-          this.wrapper.setDataTable(this.dataModel.dataTable);
-          this.wrapper.setOptions(this.dataModel.options);
+          this.wrapper.setDataTable(this.data.dataTable);
+          this.wrapper.setOptions(this.data.options);
         }
         this.wrapper.draw(this.el.nativeElement.querySelector('div'));
       });
     }
   }
-
-  //ControlValueAccessor interface
-  registerOnChange(fn: (_: any) => {}): void { this.onChange = fn; }
-  registerOnTouched(fn: () => {}): void { this.onTouched = fn; }
 }


### PR DESCRIPTION
Charts only needs one way data flow. Angular form module is only needed for two way binding. I switched the two way binding to a simpler one way property binding. It still uses OnPush change detection strategy. This actually simplifies the implementation. Updated readme and example app as well.