### PR TITLE
avoid data being both undefined or null

### DIFF
--- a/src/google-chart/google-chart.component.ts
+++ b/src/google-chart/google-chart.component.ts
@@ -33,7 +33,7 @@ export class GoogleChartComponent implements OnChanges {
   public ngOnChanges(changes: SimpleChanges):void {
     let key = 'data';
     if (changes[key]) {
-      if(this.data === null) {
+      if(!this.data) {
         return;
       }
 


### PR DESCRIPTION
If data are retrieved asynchronously, it avoids errors while undefined.