### PR TITLE
Upgrade Google Charts version to 45.2

### DIFF
--- a/src/google-charts-loader.service.ts
+++ b/src/google-charts-loader.service.ts
@@ -48,7 +48,7 @@ export class GoogleChartsLoaderService {
     return new Promise((resolve: any = Function.prototype, reject: any = Function.prototype) => {
 
       this.loadGoogleChartsScript().then(() => {
-        google.charts.load('45', {
+        google.charts.load('45.2', {
             packages: [this.chartPackage[chartType]],
             language: this.localeId,
             callback: resolve


### PR DESCRIPTION
You can find release notes of Google Charts here: https://developers.google.com/chart/interactive/docs/release_notes#june-26-2017