### PR TITLE
Catch network errors on loading

### DIFF
--- a/src/google-charts-loader.service.ts
+++ b/src/google-charts-loader.service.ts
@@ -53,7 +53,7 @@ export class GoogleChartsLoaderService {
             language: this.localeId,
             callback: resolve
         });
-      });
+      }).catch(err => reject());
     });
   }
 


### PR DESCRIPTION
When loading the first script, catch any network error so we can catch them in our app.