### PR TITLE
Add formatter support for type ColorFormat

### DIFF
--- a/src/google-chart/google-chart.component.ts
+++ b/src/google-chart/google-chart.component.ts
@@ -104,6 +104,15 @@ export class GoogleChartComponent implements OnChanges {
         const formatterConstructor = google.visualization[formatterConfig.type];
         const formatterOptions = formatterConfig.options;
         const formatter = new formatterConstructor(formatterOptions);
+        if(formatterConfig.type == 'ColorFormat' && formatterOptions) {
+          for(const range in formatterOptions.ranges) {
+            if (typeof(range.fromBgColor) != 'undefined' && typeof(range.toBgColor) != 'undefined')
+              formatter.addGradientRange(range.from, range.to, 
+                                         range.color, range.fromBgColor, range.toBgColor);
+            else
+              colorFormat.addRange(range.from, range.to, range.color, range.bgcolor);
+          }
+        }
         for (const col of formatterConfig.columns) {
           formatter.format(this.wrapper.getDataTable(), col);
         }


### PR DESCRIPTION
Since ColorFormat formatter constructor takes no arguments, we need to explicitly call `addRange` or `addGradientRange` methods
I assume the structure could be something like
```
options: {
    ranges: {from: number, to: number, fromBgColor?: number, toBgColor: number}[],...
}
```
and we could iterate through ranges to add them to the formatter

Reference: https://developers.google.com/chart/interactive/docs/reference#colorformatter